### PR TITLE
feat: 支持自定义 CPU 温度传感器

### DIFF
--- a/Controls/Components/MonitorComponentSettingsControl.xaml
+++ b/Controls/Components/MonitorComponentSettingsControl.xaml
@@ -21,6 +21,7 @@
         <converters:MonitorOptionToStringConverter x:Key="MonitorOptionConverter" />
         <converters:MonitorTypeToDiskVisibilityConverter x:Key="DiskVisibilityConverter" />
         <converters:MonitorTypeToUnitVisibilityConverter x:Key="UnitVisibilityConverter" />
+        <converters:MonitorTypeToCpuTemperatureSensorVisibilityConverter x:Key="CpuTemperatureSensorVisibilityConverter" />
         <converters:DisplayUnitToStringConverter x:Key="DisplayUnitConverter" />
 
         <!--  使用 ObjectDataProvider 提供枚举值  -->
@@ -66,6 +67,27 @@
                             MinWidth="80"
                             ItemsSource="{Binding AvailableDriveNames}"
                             SelectedItem="{Binding Settings.DriveName, Mode=TwoWay}" />
+                    </ci:SettingsCard.Switcher>
+                </ci:SettingsCard>
+
+                <ci:SettingsCard
+                    Margin="0,0,0,6"
+                    Description="选择要监控的 CPU 温度传感器"
+                    Header="CPU 温度传感器"
+                    IconGlyph="Thermometer"
+                    Visibility="{Binding Settings.MonitorType, Converter={StaticResource CpuTemperatureSensorVisibilityConverter}}">
+                    <ci:SettingsCard.Switcher>
+                        <ComboBox
+                            MinWidth="200"
+                            ItemsSource="{Binding Settings.AvailableCpuTemperatureSensors}"
+                            SelectedValue="{Binding Settings.SelectedCpuTemperatureSensorId, Mode=TwoWay}"
+                            SelectedValuePath="Id">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate DataType="{x:Type models:CpuTemperatureSensorInfo}">
+                                    <TextBlock Text="{Binding DisplayText}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
                     </ci:SettingsCard.Switcher>
                 </ci:SettingsCard>
 

--- a/Controls/Components/MonitorComponentSettingsControl.xaml.cs
+++ b/Controls/Components/MonitorComponentSettingsControl.xaml.cs
@@ -1,7 +1,10 @@
 ﻿using ClassIsland.Core.Abstractions.Controls;
 using Microsoft.Extensions.Logging;
+using MonitorIsland.Interfaces;
+using MonitorIsland.Models;
 using MonitorIsland.Models.ComponentSettings;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;

--- a/Converters/MonitorTypeToCpuTemperatureSensorVisibilityConverter.cs
+++ b/Converters/MonitorTypeToCpuTemperatureSensorVisibilityConverter.cs
@@ -1,0 +1,27 @@
+using MonitorIsland.Models;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace MonitorIsland.Converters
+{
+    /// <summary>
+    /// 将监控类型转换为CPU温度传感器选择控件的可见性
+    /// </summary>
+    public class MonitorTypeToCpuTemperatureSensorVisibilityConverter : IValueConverter
+    {
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is MonitorOption monitorType)
+            {
+                return monitorType == MonitorOption.CpuTemperature ? Visibility.Visible : Visibility.Collapsed;
+            }
+            return Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Interfaces/IMonitorService.cs
+++ b/Interfaces/IMonitorService.cs
@@ -13,8 +13,9 @@ namespace MonitorIsland.Interfaces
         /// <param name="monitorType">监控类型枚举。</param>
         /// <param name="unit">显示单位</param>
         /// <param name="driveName">磁盘盘符（仅在监控磁盘空间时使用）</param>
+        /// <param name="cpuTemperatureSensorId">CPU温度传感器ID（仅在监控CPU温度时使用）</param>
         /// <returns>格式化后的监控值字符串。</returns>
-        string GetFormattedMonitorValue(MonitorOption monitorType, DisplayUnit unit, string? driveName = null);
+        string GetFormattedMonitorValue(MonitorOption monitorType, DisplayUnit unit, string? driveName = null, string? cpuTemperatureSensorId = null);
 
         /// <summary>
         /// 获取当前内存使用量（单位：字节）。
@@ -31,8 +32,9 @@ namespace MonitorIsland.Interfaces
         /// <summary>
         /// 获取当前CPU温度（单位：摄氏度）。
         /// </summary>
+        /// <param name="sensorId">指定的传感器ID</param>
         /// <returns>CPU温度。</returns>
-        float? GetCpuTemperature();
+        float? GetCpuTemperature(string? sensorId = null);
 
         /// <summary>
         /// 获取指定磁盘的剩余空间（单位：字节）。
@@ -40,5 +42,11 @@ namespace MonitorIsland.Interfaces
         /// <param name="driveName">磁盘盘符。</param>
         /// <returns>磁盘剩余空间。</returns>
         float? GetDiskFreeSpace(string driveName);
+
+        /// <summary>
+        /// 获取所有可用的CPU温度传感器列表
+        /// </summary>
+        /// <returns>CPU温度传感器信息列表</returns>
+        List<CpuTemperatureSensorInfo> GetAvailableCpuTemperatureSensors();
     }
 }

--- a/Models/ComponentSettings/MonitorComponentSettings.cs
+++ b/Models/ComponentSettings/MonitorComponentSettings.cs
@@ -1,4 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using MonitorIsland.Controls.Components;
+using MonitorIsland.Models;
 using System.Text.Json.Serialization;
 
 namespace MonitorIsland.Models.ComponentSettings
@@ -12,6 +14,8 @@ namespace MonitorIsland.Models.ComponentSettings
         private string _driveName = "C:\\";
         private DisplayUnit _selectedUnit;
         private List<DisplayUnit> _availableUnits = [];
+        private string? _selectedCpuTemperatureSensorId;
+        private List<CpuTemperatureSensorInfo> _availableCpuTemperatureSensors = [];
 
         public MonitorComponentSettings()
         {
@@ -57,6 +61,35 @@ namespace MonitorIsland.Models.ComponentSettings
             {
                 if (value == _driveName) return;
                 _driveName = value;
+                OnPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// 选择的CPU温度传感器ID（仅在监控类型为CPU温度时使用）
+        /// </summary>
+        public string? SelectedCpuTemperatureSensorId
+        {
+            get => _selectedCpuTemperatureSensorId;
+            set
+            {
+                if (value == _selectedCpuTemperatureSensorId) return;
+                _selectedCpuTemperatureSensorId = value ?? AvailableCpuTemperatureSensors.FirstOrDefault()?.Id;
+                OnPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// 可用的CPU温度传感器列表
+        /// </summary>
+        [JsonIgnore]
+        public List<CpuTemperatureSensorInfo> AvailableCpuTemperatureSensors
+        {
+            get => _availableCpuTemperatureSensors;
+            set
+            {
+                if (Equals(value, _availableCpuTemperatureSensors)) return;
+                _availableCpuTemperatureSensors = value;
                 OnPropertyChanged();
             }
         }
@@ -127,7 +160,7 @@ namespace MonitorIsland.Models.ComponentSettings
             }
         }
 
-        private List<DisplayUnit> GetUnitsForMonitorType(MonitorOption monitorType)
+        private static List<DisplayUnit> GetUnitsForMonitorType(MonitorOption monitorType)
         {
             return monitorType switch
             {

--- a/Models/CpuTemperatureSensorInfo.cs
+++ b/Models/CpuTemperatureSensorInfo.cs
@@ -1,0 +1,38 @@
+namespace MonitorIsland.Models
+{
+    /// <summary>
+    /// CPU温度传感器信息
+    /// </summary>
+    public class CpuTemperatureSensorInfo
+    {
+        /// <summary>
+        /// 传感器唯一标识符
+        /// </summary>
+        public string Id { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 传感器名称
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 硬件名称
+        /// </summary>
+        public string HardwareName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 显示文本（硬件名称 - 传感器名称）
+        /// </summary>
+        public string DisplayText => $"{HardwareName} - {Name}";
+
+        public override bool Equals(object? obj)
+        {
+            return obj is CpuTemperatureSensorInfo other && Id == other.Id;
+        }
+
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode();
+        }
+    }
+}

--- a/Services/MonitorService.cs
+++ b/Services/MonitorService.cs
@@ -139,7 +139,10 @@ namespace MonitorIsland.Services
                 //}
 
                 if (!_temperatureSensors.TryGetValue(sensorId, out var sensor))
+                {
+                    logger.LogWarning("未找到指定的 CPU 温度传感器ID: {SensorId}", sensorId);
                     return null;
+                }
 
                 sensor.Hardware.Update();
 

--- a/Services/MonitorService.cs
+++ b/Services/MonitorService.cs
@@ -133,8 +133,6 @@ namespace MonitorIsland.Services
                     return null;
                 }
 
-// (No replacement lines; the block is removed entirely)
-
                 if (!_temperatureSensors.TryGetValue(sensorId, out var sensor))
                 {
                     logger.LogWarning("未找到指定的 CPU 温度传感器ID: {SensorId}", sensorId);

--- a/Services/MonitorService.cs
+++ b/Services/MonitorService.cs
@@ -133,10 +133,7 @@ namespace MonitorIsland.Services
                     return null;
                 }
 
-                //if (_temperatureSensors == null || !_computer.IsValueCreated)
-                //{
-                //    var computer = _computer.Value;
-                //}
+// (No replacement lines; the block is removed entirely)
 
                 if (!_temperatureSensors.TryGetValue(sensorId, out var sensor))
                 {

--- a/Services/MonitorService.cs
+++ b/Services/MonitorService.cs
@@ -9,7 +9,7 @@ namespace MonitorIsland.Services
 {
     public class MonitorService(ILogger<MonitorService> logger) : IMonitorService
     {
-        private ISensor? _tempSensor;
+        private readonly Dictionary<string, ISensor> _temperatureSensors = [];
         private readonly ulong _totalMemory = new Microsoft.VisualBasic.Devices.ComputerInfo().TotalPhysicalMemory;
 
         private readonly Lazy<PerformanceCounter> _memoryCounter = new(() =>
@@ -37,14 +37,14 @@ namespace MonitorIsland.Services
 
         private int _disposed;
 
-        public string GetFormattedMonitorValue(MonitorOption monitorType, DisplayUnit unit, string? driveName = null)
+        public string GetFormattedMonitorValue(MonitorOption monitorType, DisplayUnit unit, string? driveName = null, string? cpuTemperatureSensorId = null)
         {
             return monitorType switch
             {
                 MonitorOption.MemoryUsage => FormatValue(GetMemoryUsage(), unit, "F1"),
                 MonitorOption.MemoryUsageRate => FormatValue(GetMemoryUsage() / _totalMemory * 100, unit, "F2"),
                 MonitorOption.CpuUsage => FormatValue(GetCpuUsage(), unit, "F2"),
-                MonitorOption.CpuTemperature => FormatValue(GetCpuTemperature(), unit, "F1"),
+                MonitorOption.CpuTemperature => FormatValue(GetCpuTemperature(cpuTemperatureSensorId), unit, "F1"),
                 MonitorOption.DiskSpace => FormatValue(GetDiskFreeSpace(driveName ?? "C"), unit, "F1"),
                 _ => "未知类型"
             };
@@ -122,44 +122,72 @@ namespace MonitorIsland.Services
             }
         }
 
-        public float? GetCpuTemperature()
+        public float? GetCpuTemperature(string? sensorId = null)
         {
             try
             {
-                if (_tempSensor != null && _tempSensor.Value.HasValue)
+                // 如果没有指定传感器ID，返回null
+                if (string.IsNullOrEmpty(sensorId))
                 {
-                    _tempSensor.Hardware.Update();
-                    return _tempSensor.Value.Value;
+                    logger.LogWarning("未指定 CPU 温度传感器ID");
+                    return null;
                 }
 
+                //if (_temperatureSensors == null || !_computer.IsValueCreated)
+                //{
+                //    var computer = _computer.Value;
+                //}
+
+                if (!_temperatureSensors.TryGetValue(sensorId, out var sensor))
+                    return null;
+
+                sensor.Hardware.Update();
+
+                if (sensor.Value.HasValue)
+                    return sensor.Value.Value;
+
+                logger.LogWarning("传感器 {SensorId} 没有可用的温度值", sensorId);
+
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "获取 CPU 温度失败");
+            }
+            return null;
+        }
+
+        public List<CpuTemperatureSensorInfo> GetAvailableCpuTemperatureSensors()
+        {
+            var sensors = new List<CpuTemperatureSensorInfo>();
+            _temperatureSensors.Clear();
+
+            try
+            {
                 var computer = _computer.Value;
 
                 foreach (var hardware in computer.Hardware.Where(h => h.HardwareType == HardwareType.Cpu))
                 {
                     hardware.Update();
 
-                    _tempSensor = hardware.Sensors.FirstOrDefault(s =>
-                        s.SensorType == SensorType.Temperature && s.Name == "CPU Package");
+                    foreach (var sensor in hardware.Sensors.Where(s => s.SensorType == SensorType.Temperature))
+                    {
+                        var sensorInfo = new CpuTemperatureSensorInfo
+                        {
+                            Id = $"{hardware.Identifier}_{sensor.Identifier}",
+                            Name = sensor.Name,
+                            HardwareName = hardware.Name
+                        };
 
-                    if (_tempSensor != null && _tempSensor.Value.HasValue)
-                        return _tempSensor.Value.Value;
-
-                    _tempSensor = hardware.Sensors.FirstOrDefault(s =>
-                        s.SensorType == SensorType.Temperature && s.Name == "Core Average");
-
-                    if (_tempSensor != null && _tempSensor.Value.HasValue)
-                        return _tempSensor.Value.Value;
-
-                    logger.LogError("未找到可用的 CPU 温度传感器");
-                    _tempSensor = null;
+                        sensors.Add(sensorInfo);
+                        _temperatureSensors[sensorInfo.Id] = sensor;
+                    }
                 }
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "获取 CPU 温度失败");
-                _tempSensor = null;
+                logger.LogError(ex, "获取可用 CPU 温度传感器失败");
             }
-            return null;
+            return sensors;
         }
 
         /// <summary>
@@ -184,7 +212,7 @@ namespace MonitorIsland.Services
             if (_computer.IsValueCreated)
             {
                 _computer.Value.Close();
-                _tempSensor = null;
+                _temperatureSensors.Clear();
                 logger.LogDebug("释放硬件监控组件资源");
             }
 


### PR DESCRIPTION
- 在 MonitorComponent.xaml.cs 中实现 CPU 温度传感器的加载和选择逻辑。
- 更新 IMonitorService 接口，支持 CPU 温度传感器 ID，并添加获取可用传感器的方法。
- 在 MonitorComponentSettings.cs 中添加 SelectedCpuTemperatureSensorId 和 AvailableCpuTemperatureSensors 属性。
- 修改 MonitorService.cs 中的获取 CPU 温度方法，支持指定传感器 ID。
- 在 XAML 文件中添加设置卡片以选择 CPU 温度传感器，并使用新的可见性转换器。
- 新增 CpuTemperatureSensorInfo 类，用于表示 CPU 温度传感器信息。