### PR TITLE
Dispose monitor providers on switch/unload and simplify MonitorService async

### DIFF
--- a/MonitorIsland/Controls/Components/MonitorComponent.axaml.cs
+++ b/MonitorIsland/Controls/Components/MonitorComponent.axaml.cs
@@ -74,6 +74,8 @@ namespace MonitorIsland.Controls.Components
         {
             _timer.Stop();
             Settings.PropertyChanged -= OnSettingsPropertyChanged;
+            Settings.SelectedProviderBase?.Dispose();
+            Settings.SelectedProviderBase = null;
         }
 
         private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -97,12 +99,19 @@ namespace MonitorIsland.Controls.Components
             }
 
             var selected = Settings.SelectedProvider;
+            var oldProvider = Settings.SelectedProviderBase;
 
             var providerInstance = MonitorProviderBase.GetInstance(selected);
             if (providerInstance is null)
             {
                 return;
             }
+
+            if (oldProvider is not null && !ReferenceEquals(oldProvider, providerInstance))
+            {
+                oldProvider.Dispose();
+            }
+
             var baseType = providerInstance.GetType().BaseType;
             if (baseType is not null
                 && baseType.IsGenericType

--- a/MonitorIsland/Services/MonitorService.cs
+++ b/MonitorIsland/Services/MonitorService.cs
@@ -10,17 +10,17 @@ namespace MonitorIsland.Services
     {
         private readonly ILogger<MonitorService> Logger = logger;
 
-        public async Task<string?> GetDataFromProviderAsync(MonitorProviderBase providerInstance)
+        public Task<string?> GetDataFromProviderAsync(MonitorProviderBase providerInstance)
         {
             try
             {
                 var value = providerInstance.GetData();
-                return value;
+                return Task.FromResult<string?>(value);
             }
             catch (Exception ex)
             {
                 Logger.LogError(ex, "从提供器 {ProviderName} 获取数据时出现错误", providerInstance.GetType()?.GetCustomAttribute<MonitorProviderInfoAttribute>()?.Name);
-                return null;
+                return Task.FromResult<string?>(null);
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Prevent leaking provider instances and underlying resources (e.g. `PerformanceCounter`) after the recent refactor by ensuring provider lifecycle is handled correctly. 
- Remove an unnecessary `async` state machine from the data fetch path to slightly reduce overhead while preserving behavior.

### Description
- In `MonitorIsland/Controls/Components/MonitorComponent.axaml.cs` dispose the current `Settings.SelectedProviderBase` and set it to `null` when the component unloads. 
- In `MonitorIsland/Controls/Components/MonitorComponent.axaml.cs` detect the old provider in `ChangeProvider()` and call `Dispose()` when switching to a different provider (with a `ReferenceEquals` check to avoid disposing the same instance). 
- In `MonitorIsland/Services/MonitorService.cs` remove the unnecessary `async` from `GetDataFromProviderAsync` and return results using `Task.FromResult(...)`, preserving exception handling and caller-facing `Task<string?>` signature.

### Testing
- Ran `git diff --check` which reported no problems. 
- Attempted `dotnet build MonitorIsland.sln -v minimal` which could not be executed in this environment because `dotnet` is not installed, so a full build was not validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d2a300dfc8324a1b2d1e6b7febeb8)