### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,13 @@ on:
   push:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build_app:
+    permissions:
+      contents: write
     runs-on: windows-latest
     name: Build
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/LiuYan-xwx/MonitorIsland/security/code-scanning/2](https://github.com/LiuYan-xwx/MonitorIsland/security/code-scanning/2)

Add explicit `permissions` to the workflow so default token access is not implicitly inherited.

Best fix for this file:
- Add a **workflow-level** `permissions` block with minimal baseline access:
  - `contents: read`
- Add a **job-level override** for `build_app` to permit release creation:
  - `contents: write`

This preserves behavior (the release step still works) while making permission intent explicit and constrained.  
Only `.github/workflows/build.yml` needs edits; no imports/dependencies/methods are involved.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
